### PR TITLE
Display card styles init

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,11 @@ const App = () => {
               <DisplayCard
                 key={item.id}
                 name={item.name}
-                spriteFront={item.sprites.front_default}
+                spriteFront={
+                  item.sprites.versions["generation-v"]["black-white"][
+                    "animated"
+                  ]["front_default"]
+                }
                 stats={item.stats}
                 type={item.types[0].type.name}
               />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,15 @@ const App = () => {
         </form>
         <div>
           {entities.map((item) => {
-            return <DisplayCard key={item.id} name={item.name} />;
+            return (
+              <DisplayCard
+                key={item.id}
+                name={item.name}
+                spriteFront={item.sprites.front_default}
+                stats={item.stats}
+                type={item.types[0].type.name}
+              />
+            );
           })}
         </div>
       </div>

--- a/src/components/DisplayCard/DisplayCard.module.css
+++ b/src/components/DisplayCard/DisplayCard.module.css
@@ -1,0 +1,11 @@
+.displayCard {
+  font-size: 2rem;
+  width: fit-content;
+  height: fit-content;
+  padding: 1rem;
+  margin: 1rem;
+}
+
+li {
+  list-style: none;
+}

--- a/src/components/DisplayCard/DisplayCard.tsx
+++ b/src/components/DisplayCard/DisplayCard.tsx
@@ -1,14 +1,104 @@
 import { capitaliseFirstLetter } from "../../utils/stringFunctions";
 
+import style from "./DisplayCard.module.css";
+
+type EntityStats = {
+  base_stat: number;
+  stat: {
+    name: string;
+    url: string;
+  };
+};
+
 export type DisplayCardProps = {
   key: number;
   name: string;
+  spriteFront: string;
+  stats: EntityStats[];
+  type: string;
+};
+
+interface backgroundColourType {
+  [key: string]: {
+    color: string;
+  };
+}
+
+const backgroundColor: backgroundColourType = {
+  normal: {
+    color: "#AAAA99",
+  },
+  fire: {
+    color: "#FF4422",
+  },
+  water: {
+    color: "#3399FF",
+  },
+  electric: {
+    color: "#FFCC33",
+  },
+  grass: {
+    color: "#77CC55",
+  },
+  ice: {
+    color: "#66CCFF",
+  },
+  fighting: {
+    color: "#BB5544",
+  },
+  poison: {
+    color: "#AA5599",
+  },
+  ground: {
+    color: "#DDBB55",
+  },
+  flying: {
+    color: "#8899FF",
+  },
+  psychic: {
+    color: "#FF5599",
+  },
+  bug: {
+    color: "#AABB22",
+  },
+  rock: {
+    color: "#BBAA66",
+  },
+  ghost: {
+    color: "#6666BB",
+  },
+  dragon: {
+    color: "#6666BB",
+  },
+  dark: {
+    color: "#775544",
+  },
+  steel: {
+    color: "#AAAABB",
+  },
+  fairy: {
+    color: "#EE99EE",
+  },
 };
 
 export const DisplayCard = (props: DisplayCardProps) => {
   return (
-    <div>
+    <div
+      className={style.displayCard}
+      style={{ backgroundColor: backgroundColor[props.type].color }}
+    >
+      <img src={props.spriteFront} />
       <p>{capitaliseFirstLetter(props.name)}</p>
+      <p>{capitaliseFirstLetter(props.type)}</p>
+      <ul>
+        {props.stats.map((stat) => {
+          return (
+            <li>
+              {capitaliseFirstLetter(stat.stat.name)}: {stat.base_stat}
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,7 @@
   font-family: "Noto Sans JP", system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
+  font-size: 10px;
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);

--- a/src/utils/fetchFunctions.ts
+++ b/src/utils/fetchFunctions.ts
@@ -3,6 +3,5 @@ export const fetchSingleCharacter = async (queryString: string) => {
   const fetchURL = `https://pokeapi.co/api/v2/pokemon/${queryString.toLowerCase()}/`;
   const response = await fetch(fetchURL);
   const data = await response.json();
-  console.log(data);
   return data;
 };

--- a/src/utils/fetchFunctions.ts
+++ b/src/utils/fetchFunctions.ts
@@ -1,7 +1,8 @@
 // Fetch a single character from the API.
 export const fetchSingleCharacter = async (queryString: string) => {
-  const fetchURL = `https://pokeapi.co/api/v2/pokemon/${queryString}/`;
+  const fetchURL = `https://pokeapi.co/api/v2/pokemon/${queryString.toLowerCase()}/`;
   const response = await fetch(fetchURL);
   const data = await response.json();
+  console.log(data);
   return data;
 };


### PR DESCRIPTION
# Pull Request

## Description of change 

Added some baseline styles to DisplayCard, including a background colour based on the type of Pokemon returned from the fetch. More styles to follow once the overall card is figured out.

## Notes to highlight

Sneakily included in this PR are; 
1. I realised that the API doesn't like capital letters. i.e "Pikachu" will return an error, so search for "pikachu" instead. To fix this; I added .toLowerCase() to the search query, just in case the user decides to capitalise anything. 
2. The base font-size of the repo is 10px, so rem calculations should now be much simpler. 

## Questions for reviewers

## Screenshots / Videos

![image](https://github.com/JGardener/pokemon-battle/assets/47278538/997302ec-835d-404b-a92f-829e06fc5abd)
